### PR TITLE
Fix message sending bug in dodge game

### DIFF
--- a/app/src/components/game/tabs/chat/Chat.tsx
+++ b/app/src/components/game/tabs/chat/Chat.tsx
@@ -26,9 +26,16 @@ export default function Chat() {
   }, [messages]);
 
   const handleSendMessage = (message: string) => {
-    if (id) {
+    if (id && message.trim()) {
       gameService.sendMessage(message);
       setMessage("");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSendMessage(message);
     }
   };
 
@@ -60,6 +67,7 @@ export default function Chat() {
         <input
           value={message}
           onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={handleKeyDown}
           type="text"
           placeholder={t("Envoie ton message...")}
           className="flex-1 px-3 py-2 bg-[var(--text-color)]/15 backdrop-blur-sm rounded-lg text-[var(--text-color)] text-sm placeholder-[var(--action-chat-secondary-text-color)]/60 focus:outline-none focus:ring-1 focus:ring-[var(--action-choice-active-color)] transition-all duration-200"


### PR DESCRIPTION
Enable sending chat messages by pressing Enter and prevent sending empty messages.

This resolves DOG-24 where users could only send messages by clicking the button, not by pressing the Enter key.

---
Linear Issue: [DOG-24](https://linear.app/dodge/issue/DOG-24/when-i-tap-on-button-enter-to-send-message-in-game-in-app-the-message)

<a href="https://cursor.com/background-agent?bcId=bc-0322359a-f999-48af-88c8-00c7142c1e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0322359a-f999-48af-88c8-00c7142c1e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

